### PR TITLE
Fix linting error, added runner config passthrough

### DIFF
--- a/.github/workflows/call-local-super-linter.yaml
+++ b/.github/workflows/call-local-super-linter.yaml
@@ -5,6 +5,9 @@
 
 name: Lint
 
+# disable all permissions by default. We will enable necessary permissions in a job
+permissions: {}
+
 on:
   push:
     branches:
@@ -23,6 +26,8 @@ jobs:
     name: Call Super-Linter
         
     uses: ./.github/workflows/reusable-super-linter.yaml
+#    with:
+#      runner-labels: '["self-hosted", "Linux"]'
     
     permissions:
       contents: read # clone the repo to lint

--- a/.github/workflows/reusable-super-linter.yaml
+++ b/.github/workflows/reusable-super-linter.yaml
@@ -26,6 +26,11 @@ on:
         description: A regex to exclude files from linting
         required: false
         type: string
+      runner-labels:
+        description: 'runs-on override (format: ''["self-hosted", "Linux"]'')'
+        required: false
+        type: string
+        default: '["ubuntu-latest"]'
 
 permissions:
   contents: read            # git permissions to repo pull/push
@@ -36,7 +41,7 @@ jobs:
 
     name: Super-Linter
 
-    runs-on: ubuntu-latest
+    runs-on: "${{ fromJSON(inputs.runner-labels) }}"
 
     steps:
       - name: Checkout Code

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ jobs:
       ### A regex to exclude files from linting
       ### defaults to empty
       # filter-regex-exclude: html/.*
+
+      ### For adjusting the runner's configuration
+      ### defaults to '["ubuntu-latest"]'
+      # runner-labels: '["self-hosted", "Linux"]'
+
 ```
 
 ## How to run Super-Linter locally


### PR DESCRIPTION
[+] additional input in `reusable-super-linter.yaml` to control `runs-on:` 
[+] commented example how to run `call-local-super-linter.yaml` on a self-hosted GHA runner 
[+] updated `README` with example of usage
[!] fixed linting error by adding `permissions: {}` on the workflow level of `call-local-super-linter.yaml`